### PR TITLE
Rebase the fiat-x25519 backend on release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2018"
 # Be sure to update the version in README.md
 version = "0.6.0"
 authors = [
-    "Isis Lovecruft <isis@patternsinthevoid.net>", 
+    "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
     "Henry de Valence <hdevalence@hdevalence.ca>",
 ]
@@ -30,7 +30,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 features = ["nightly"]
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false }
+curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat2", version = "2", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
@@ -50,5 +50,6 @@ default = ["std", "u64_backend"]
 serde = ["our_serde", "curve25519-dalek/serde"]
 std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly"]
+fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]


### PR DESCRIPTION
I'll also submit a PR to switch the libra dependency pointers from fiat to fiat2, once the updates to branch fiat2 of:
- `calibra/curve25519-dalek`
- `calibra/x25519-dalek`
- `calibra/ed25519-dalek`
are all in place and merged.

A variant of this which points to my own fork, suitable for testing, is at:
https://github.com/huitseeker/x25519-dalek/tree/fiat2-test