### PR TITLE
Pick up the latest curve25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # - update CHANGELOG
 version = "1.1.0"
 authors = [
-    "Isis Lovecruft <isis@patternsinthevoid.net>", 
+    "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
     "Henry de Valence <hdevalence@hdevalence.ca>",
 ]
@@ -33,7 +33,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 features = ["nightly"]
 
 [dependencies]
-curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat3", version = "3", default-features = false }
+curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat4", version = "3", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature


### PR DESCRIPTION
and the fiat-crypto backend.

The current PR is opened against fiat4, which is the branch automatically picked up by diem. To ensure we have the ability to have rollbacks, it should instead be merged into a **new** branch that we will then point diem towards (preserving the fiat4 pointer in case we need a rollback). To create this new branch (fiat5), I suggest:
```
cd checkout/of/x25519-dalek
NOVI_FORK=$(git remote -v| grep 'github\.com/novifinancial/x25519-dalek'| awk '{print $1}'|uniq)
git checkout fiat4 && git reset --hard $NOVI_FORK/fiat4
git checkout -b fiat5
git push -u $NOVI_FORK fiat5
```

Then we can retarget this present PR to the newly created fiat5 and merge.